### PR TITLE
Add go.* files to docker build

### DIFF
--- a/tgapi/deploy/Dockerfile
+++ b/tgapi/deploy/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.19
 
+ADD go.* /go/src/github.com/replicatedhq/kurl-testgrid/
 ADD tgapi /go/src/github.com/replicatedhq/kurl-testgrid/tgapi
 ADD tgrun /go/src/github.com/replicatedhq/kurl-testgrid/tgrun
 WORKDIR /go/src/github.com/replicatedhq/kurl-testgrid/tgapi

--- a/tgrun/Dockerfile
+++ b/tgrun/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.19-alpine AS builder
 
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
 
+ADD go.* /go/src/github.com/replicatedhq/kurl-testgrid/
 ADD tgapi /go/src/github.com/replicatedhq/kurl-testgrid/tgapi
 ADD tgrun /go/src/github.com/replicatedhq/kurl-testgrid/tgrun
 


### PR DESCRIPTION
fixes build error:

```
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
```