### PR TITLE
Use k8s 1.25 and containerd

### DIFF
--- a/deploy/tg-script.sh
+++ b/deploy/tg-script.sh
@@ -14,7 +14,7 @@ mount /dev/nvme0n1 /var/openebs/local/
 
 echo "Installing kURL"
 INSTALL_SCRIPT=/root/kurl-install.sh
-curl https://kurl.sh/2e7f363 > $INSTALL_SCRIPT
+curl https://kurl.sh/1c12ac6 > $INSTALL_SCRIPT
 sed -i 's/parse_yaml_into_bash_variables$/parse_yaml_into_bash_variables\n    PRIVATE_ADDRESS=$(\/sbin\/ifconfig bond0:0 | awk "\/inet \/ {print \\$2}")/' $INSTALL_SCRIPT 
 chmod +x $INSTALL_SCRIPT
 ./$INSTALL_SCRIPT


### PR DESCRIPTION
changing

```
apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata:
  name: 2e7f363
spec:
  kubernetes:
    version: 1.23.15
    serviceCIDR: 172.19.0.0/16
  docker:
    version: 20.10.17
  weave:
    version: 2.8.1-20221122
    podCIDR: 172.18.0.0/16
  openebs:
    version: 3.3.0
    isLocalPVEnabled: true
    localPVStorageClassName: default
```

to

```
apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata:
  name: 1c12ac6
spec:
  kubernetes:
    version: 1.25.5
    serviceCIDR: 172.19.0.0/16
  weave:
    version: 2.8.1-20221122
    podCIDR: 172.18.0.0/16
  openebs:
    version: 3.3.0
    isLocalPVEnabled: true
    localPVStorageClassName: default
  containerd:
    version: 1.6.12
```