### PR TITLE
feat: collect support bundle in airgapped tests

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -11,6 +11,8 @@ function run_install() {
     fi
     AIRGAP_FLAG=
 
+    curl -sSL https://kots.io -H'User-Agent: Replicated_Troubleshoot/v1beta1' > /tmp/support-bundle-spec.yaml
+
     if [ "$AIRGAP" = "1" ]; then
         AIRGAP_FLAG=airgap
 
@@ -448,7 +450,7 @@ function collect_debug_info_sonobuoy() {
 function collect_support_bundle() {
     echo "collecting support bundle"
 
-    /usr/local/bin/kubectl-support_bundle https://kots.io
+    /usr/local/bin/kubectl-support_bundle /tmp/support-bundle-spec.yaml
     SUPPORT_BUNDLE=$(ls -1 ./ | grep support-bundle-)
     if [ -n "$SUPPORT_BUNDLE" ]; then
         echo "completed support bundle collection"


### PR DESCRIPTION
Support bundle collection fails in airgap tests with the following error:

```
2023-01-30 12:52:08+00:00 kurl install failed
2023-01-30 12:52:08+00:00 nullnullcollecting support bundle
Error: failed to load support bundle spec: failed to get spec from URL: execute request: Get "https://kots.io": dial tcp 172.67.183.104:443: connect: connection refused
```

https://testgrid.kurl.sh/run/STAGING-release-v2023.01.23-0-0be41f75-20230130102645?kurlLogsInstanceId=iczzwxxbjuihopco&nodeId=iczzwxxbjuihopco-initialprimary#L0