### PR TITLE
Chores

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -490,6 +490,7 @@ function wait_for_cluster_ready() {
         if [ $i -gt 20 ]; then
             report_failure "cluster_not_ready"
             report_status_update "failed"
+            collect_debug_info_after_kurl || true
             collect_support_bundle
             send_logs
             exit 1

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,6 +1,9 @@
 SHELL := /bin/bash
 PROJECT_NAME ?= tgweb
 
+.PHONY: all
+all: deps lint build-okteto
+
 .PHONY: deps
 deps:
 	npm install


### PR DESCRIPTION
Adds debug info after wait_for_cluster_ready failure to make a failure such as [this](https://testgrid.kurl.sh/run/pr-4024-428fba7-flannel-0.21.0-k8s-ctrd-2023-02-06T04:03:20Z?kurlLogsInstanceId=zdkvhakuqwjcwwii&nodeId=zdkvhakuqwjcwwii-initialprimary) more debuggable

Follows the pattern in other services with `make all` for building the project.