### PR TITLE
chore: increase timeout for "primary node is done".

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/common.sh
+++ b/tgrun/pkg/runner/vmi/embed/common.sh
@@ -102,7 +102,7 @@ function wait_for_initprimary_done()
     fi
     echo "initprimary not ready"
     i=$((i+1))
-    if [ $i -gt 20 ]; then
+    if [ $i -gt 45 ]; then
       echo "wait_for_initprimary_done timeout"
       report_status_update "failed"
       send_logs

--- a/tgrun/pkg/runner/vmi/embed/common.sh
+++ b/tgrun/pkg/runner/vmi/embed/common.sh
@@ -102,7 +102,7 @@ function wait_for_initprimary_done()
     fi
     echo "initprimary not ready"
     i=$((i+1))
-    if [ $i -gt 45 ]; then
+    if [ $i -gt 90 ]; then
       echo "wait_for_initprimary_done timeout"
       report_status_update "failed"
       send_logs


### PR DESCRIPTION
The upgrade timeout in the primary node is 45 minutes. This PR increases the timeout used in the worker node. This is the timeout for the primary node to report as "done" (i.e. finished).

Read comments [here](https://app.shortcut.com/replicated/story/69495/longhorn-to-rook-test-grid-times-out) to understand the context.