### PR TITLE
Bump timeout on upgrades to 60mins

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -100,7 +100,7 @@ function run_upgrade() {
     echo "running kurl upgrade at '$(date)'"
     send_logs
 
-    cat install.sh | timeout 45m bash -s $AIRGAP_UPGRADE_FLAG ${KURL_FLAGS[@]}
+    cat install.sh | timeout 60m bash -s $AIRGAP_UPGRADE_FLAG ${KURL_FLAGS[@]}
     KURL_EXIT_STATUS=$?
 
     if [ "$KURL_EXIT_STATUS" -eq 0 ]; then


### PR DESCRIPTION
Recent [staging-daily test](https://testgrid.kurl.sh/run/STAGING-daily-10680f4-2023-02-23T01:28:57Z) for **rook-upgrade-to-15** run were failing due to not having enough time to perform the upgrade. This PR bumps the upgrade timeout. The drawback is that these tests will take longer BUT they will pass.