### PR TITLE
feat: disable yum repos on airgap installs

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -352,6 +352,10 @@ function disable_internet() {
 
     iptables -L
 
+    # disable yum repos
+    find /etc/yum.repos.d/ -maxdepth 1 -name '*.repo' -exec mv "{}" "{}.bak" \;
+    yum clean metadata
+
     echo "testing disabled internet"
     curl -v --connect-timeout 5 --max-time 5 "http://www.google.com"
     local exit_status="$?"

--- a/tgrun/pkg/runner/vmi/embed/testhelpers.sh
+++ b/tgrun/pkg/runner/vmi/embed/testhelpers.sh
@@ -577,3 +577,20 @@ function check_and_customize_kurl_integration_test_application() {
 
     echo "kurl integration test application still working after the upgrade."
 }
+
+function is_rhel_9_variant() {
+    if grep '^ID=' /etc/os-release | grep -qE '(centos|rhel|ol|rocky)' ; then
+        if grep '^VERSION_ID=' /etc/os-release | grep -q '=*"9' ; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+function rhel_9_install_host_packages() {
+    local packages=("$@")
+    if is_rhel_9_variant ; then
+      # install required host packages
+      yum install -y "${packages[@]}"
+    fi
+}


### PR DESCRIPTION
disabling yum repos in the pre install script is too late and the testgrid setup script is failing with error

https://testgrid.kurl.sh/run/STAGING-release-v2023.03.21-0-53077927-20230327232555?kurlLogsInstanceId=bbockuwlmvogoooe&nodeId=bbockuwlmvogoooe-initialprimary#L0

```
Error: There are no enabled repositories in "/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d".
```

this will disable yum repos and add convenience functions for installing yum packages prior to disabling.