### PR TITLE
fix: kots test app failure checking endpoint

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/testhelpers.sh
+++ b/tgrun/pkg/runner/vmi/embed/testhelpers.sh
@@ -508,7 +508,7 @@ function install_and_customize_kurl_integration_test_application() {
     local app_content
     for i in $(seq 1 24); do
         svc_ip=$(kubectl -n default get service nginx | tail -n1 | awk '{ print $3}')
-        app_content=$(curl -s $svc_ip 2>&1)
+        app_content=$(curl -s $svc_ip 2>&1 || true)
         if [ "$app_content" == "installation" ]; then
             break
         fi

--- a/tgrun/pkg/runner/vmi/embed/testhelpers.sh
+++ b/tgrun/pkg/runner/vmi/embed/testhelpers.sh
@@ -565,7 +565,7 @@ function check_and_customize_kurl_integration_test_application() {
 
     for i in $(seq 1 24); do
         svc_ip=$(kubectl -n default get service nginx | tail -n1 | awk '{ print $3}')
-        app_content=$(curl -s $svc_ip 2>&1)
+        app_content=$(curl -s $svc_ip 2>&1 || true)
         if [ "$app_content" == "upgrade" ]; then
             break
         fi


### PR DESCRIPTION
Do not fail immediately if the curl command returns with a non-zero exit code. Retry for the full 25 times.

https://testgrid.kurl.sh/run/ETHAN-20230407-cust-3?kurlLogsInstanceId=wesnqvsdvdkqxleb&nodeId=wesnqvsdvdkqxleb-initialprimary#L0

```
2023-04-07 19:14:50+00:00 kurl integration test application customized, waiting 2m for the deployment.
+ for i in $(seq 1 24)
++ kubectl -n default get service nginx
++ awk '{ print $3}'
++ tail -n1
+ svc_ip=10.96.1.5
++ curl -s 10.96.1.5
+ app_content=
+ local exit_status=7
+ '[' 7 -ne 0 ']'
+ report_failure post_install_script
+ local failure=post_install_script
```