### PR TITLE
fix: fail download on error

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/primarynodecmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/primarynodecmd.sh
@@ -12,7 +12,7 @@ function runJoinCommand()
 
 function runAirgapJoinCommand()
 {
-  curl -sSL -o install.tar.gz "$KURL_URL"
+  curl -fsSL -o install.tar.gz "$KURL_URL"
   tar -xzf install.tar.gz
   joinCommand=$(get_join_command)
   primaryJoin=$(echo "$joinCommand" | sed 's/{.*primaryJoin":"*\([0-9a-zA-Z=]*\)"*,*.*}/\1/' | base64 -d)

--- a/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -17,7 +17,7 @@ function run_install() {
     fi
     AIRGAP_FLAG=
 
-    curl -sSL https://kots.io -H'User-Agent: Replicated_Troubleshoot/v1beta1' > /tmp/support-bundle-spec.yaml
+    curl -fsSL https://kots.io -H'User-Agent: Replicated_Troubleshoot/v1beta1' > /tmp/support-bundle-spec.yaml
 
     if [ "$TESTGRID_AIRGAP" = "1" ]; then
         AIRGAP_FLAG=airgap
@@ -27,11 +27,11 @@ function run_install() {
 
         echo "downloading install bundle"
 
-        curl -sSL -o install.tar.gz "$KURL_URL"
+        curl -fsSL -o install.tar.gz "$KURL_URL"
         if [ -n "$KURL_UPGRADE_URL" ]; then
             echo "downloading upgrade bundle"
 
-            curl -sSL -o upgrade.tar.gz "$KURL_UPGRADE_URL"
+            curl -fsSL -o upgrade.tar.gz "$KURL_UPGRADE_URL"
         fi
 
         disable_internet

--- a/tgrun/pkg/runner/vmi/embed/secondarynodecmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/secondarynodecmd.sh
@@ -12,7 +12,7 @@ function runJoinCommand()
 
 function runAirgapJoinCommand()
 {
-  curl -sSL -o install.tar.gz "$KURL_URL"
+  curl -fsSL -o install.tar.gz "$KURL_URL"
   tar -xzf install.tar.gz
   joinCommand=$(get_join_command)
   secondaryJoin=$(echo "$joinCommand" | sed 's/{.*secondaryJoin":"*\([0-9a-zA-Z=]*\)"*,*.*}/\1/' | base64 -d)


### PR DESCRIPTION
i think this the curl request to download the bundle is failing silently. im hoping this will cause the script to fail

https://testgrid.kurl.sh/run/ETHAN-20230407-cust-6?kurlLogsInstanceId=sskrkvqklnosrkfc&nodeId=sskrkvqklnosrkfc-initialprimary#L0

```
+ curl -sSL -o install.tar.gz https://kurl.sh/bundle/0b47550.tar.gz
2023-04-07 21:44:03+00:00 downloading install bundle
+ '[' -n https://staging.kurl.sh/bundle/d78a3cd.tar.gz ']'
+ echo 'downloading upgrade bundle'
+ curl -sSL -o upgrade.tar.gz https://staging.kurl.sh/bundle/d78a3cd.tar.gz
2023-04-07 21:44:03+00:00 downloading upgrade bundle
...
+ echo 'internet disabled'
+ tar -xzvf install.tar.gz
2023-04-07 21:47:38+00:00 internet disabled
+ local tar_exit_status=0
+ '[' 0 -ne 0 ']'
++ date
+ echo 'running kurl install at '\''Fri Apr  7 21:47:38 UTC 2023'\'''
+ send_logs
```