### PR TITLE
fix: kurl integration test application get nginx service ip

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/testhelpers.sh
+++ b/tgrun/pkg/runner/vmi/embed/testhelpers.sh
@@ -507,14 +507,17 @@ function install_and_customize_kurl_integration_test_application() {
     local svc_ip
     local app_content
     for i in $(seq 1 24); do
-        svc_ip=$(kubectl -n default get service nginx | tail -n1 | awk '{ print $3}')
-        app_content=$(curl -s $svc_ip 2>&1 || true)
-        if [ "$app_content" == "installation" ]; then
-            break
+        if svc_ip=$(kubectl -n default get service nginx | tail -n1 | awk '{ print $3}') ; then
+          app_content=$(curl -s "$svc_ip" 2>&1 || true)
+          if [ "$app_content" == "installation" ]; then
+              break
+          fi
+          echo "attempt $i to read kurl integration test application ($svc_ip) failed, result:"
+          echo "$app_content"
+        else
+          echo "attempt $i to read kurl integration test application failed"
         fi
 
-        echo "attempt $i to read kurl integration test application ($svc_ip) failed, result:"
-        echo $app_content
         sleep 5
     done
 


### PR DESCRIPTION
bash -opipefail is causing this statement to fail if the nginx service is not yet deployed.

https://testgrid.kurl.sh/run/ETHAN-20230410-cust-1?kurlLogsInstanceId=dhvljjekchobwprx&nodeId=dhvljjekchobwprx-initialprimary#L0

```
2023-04-10 18:27:13+00:00 kurl integration test application customized, waiting 2m for the deployment.
+ for i in $(seq 1 24)
++ tail -n1
++ awk '{ print $3}'
++ kubectl -n default get service nginx
Error from server (NotFound): services "nginx" not found
+ svc_ip=
+ local exit_status=1
+ '[' 1 -ne 0 ']'
```