### PR TITLE
fix: retry download and untar airgap files

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/common.sh
+++ b/tgrun/pkg/runner/vmi/embed/common.sh
@@ -120,3 +120,32 @@ function is_airgap()
   fi
   echo $airgap
 }
+
+function retry() {
+    local retries=$1
+    shift
+    local count=0
+    until "$@"; do
+        exit_code=$?
+        count=$((count + 1))
+        if [ $count -lt "$retries" ]; then
+            echo "Retry $count/$retries exited $exit_code, retrying in 15 seconds..."
+            sleep 1
+        else
+            echo "Retry $count/$retries exited $exit_code, no more retries left."
+            return $exit_code
+        fi
+    done
+}
+
+function download_and_verify_tarball() {
+    local url=$1
+    local outfile=$2
+    echo "Downloading $url to $outfile"
+    curl -fsSL -o "$outfile" "$url"
+    exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        return $exit_code
+    fi
+    tar -tzf "$outfile" >/dev/null
+}

--- a/tgrun/pkg/runner/vmi/embed/primarynodecmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/primarynodecmd.sh
@@ -12,7 +12,7 @@ function runJoinCommand()
 
 function runAirgapJoinCommand()
 {
-  curl -fsSL -o install.tar.gz "$KURL_URL"
+  retry 5 download_and_verify_tarball "$KURL_URL" install.tar.gz
   tar -xzf install.tar.gz
   joinCommand=$(get_join_command)
   primaryJoin=$(echo "$joinCommand" | sed 's/{.*primaryJoin":"*\([0-9a-zA-Z=]*\)"*,*.*}/\1/' | base64 -d)

--- a/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -27,11 +27,28 @@ function run_install() {
 
         echo "downloading install bundle"
 
-        curl -fsSL -o install.tar.gz "$KURL_URL"
+        retry 5 download_and_verify_tarball "$KURL_URL" install.tar.gz
+        local exit_status="$?"
+        if [ "$exit_status" -ne 0 ]; then
+            echo "failed to download and verify airgap file with status $exit_status"
+            send_logs
+            report_failure "airgap_download"
+            report_status_update "failed"
+            exit 1
+        fi
+
         if [ -n "$KURL_UPGRADE_URL" ]; then
             echo "downloading upgrade bundle"
 
-            curl -fsSL -o upgrade.tar.gz "$KURL_UPGRADE_URL"
+            retry 5 download_and_verify_tarball "$KURL_UPGRADE_URL" upgrade.tar.gz
+            local exit_status="$?"
+            if [ "$exit_status" -ne 0 ]; then
+                echo "failed to download and verify airgap file with status $exit_status"
+                send_logs
+                report_failure "airgap_download"
+                report_status_update "failed"
+                exit 1
+            fi
         fi
 
         disable_internet

--- a/tgrun/pkg/runner/vmi/embed/secondarynodecmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/secondarynodecmd.sh
@@ -12,7 +12,7 @@ function runJoinCommand()
 
 function runAirgapJoinCommand()
 {
-  curl -fsSL -o install.tar.gz "$KURL_URL"
+  retry 5 download_and_verify_tarball "$KURL_URL" install.tar.gz
   tar -xzf install.tar.gz
   joinCommand=$(get_join_command)
   secondaryJoin=$(echo "$joinCommand" | sed 's/{.*secondaryJoin":"*\([0-9a-zA-Z=]*\)"*,*.*}/\1/' | base64 -d)


### PR DESCRIPTION
This is a workaround for the Airgap Download errors we often get