### PR TITLE
fix: omit last version in step upgrade bundle

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/testhelpers.sh
+++ b/tgrun/pkg/runner/vmi/embed/testhelpers.sh
@@ -633,8 +633,7 @@ function kubernetes_step_versions() {
     curl -fsL "$installer_url" \
         | grep -m1 '^STEP_VERSIONS=' \
         | sed -E 's/^.+1\.'"$(semver_minor_version "$from_version")"'\.[0-9]+ //' \
-        | sed -E 's/(^.+) 1\.'"$(semver_minor_version "$to_version")"'\.[0-9]+ ?.+/\1/' \
-        | sed 's/$/ '"$to_version"'/'
+        | sed -E 's/(^.+) 1\.'"$(semver_minor_version "$to_version")"'\.[0-9]+ ?.+/\1/'
 }
 function kubernetes_step_version_packages() {
     echo "kubernetes-$(echo "$1" | xargs | sed 's/ /,kubernetes-/g')"


### PR DESCRIPTION
With [this change](https://github.com/replicatedhq/kURL/pull/4396) the to version is not longer necessary.

Fixes

https://testgrid.kurl.sh/run/STAGING-release-v2023.04.13-0-360a5007-20230419170331?kurlLogsInstanceId=tkjyagdmrydddvei&nodeId=tkjyagdmrydddvei-initialprimary

```
023-04-19 18:08:36+00:00 ⚙  Upgrading Kubernetes from 1.23.17 to 1.26.3
2023-04-19 18:08:36+00:00 This involves upgrading from 1.23 to 1.24, 1.24 to 1.25, and 1.25 to 1.26.
2023-04-19 18:08:36+00:00 This may take some time.
2023-04-19 18:08:36+00:00 ⚙  Downloading assets required for Kubernetes 1.23.17 to 1.26.3 upgrade
2023-04-19 18:08:36+00:00 The following packages are not available locally, and are required:
2023-04-19 18:08:36+00:00     kubernetes-1.24.12.tar.gz
2023-04-19 18:08:36+00:00     kubernetes-1.25.8.tar.gz
2023-04-19 18:08:36+00:00 
2023-04-19 18:08:36+00:00 You can download them with the following command:
2023-04-19 18:08:36+00:00 
2023-04-19 18:08:36+00:00     curl -LO https://staging.kurl.sh/bundle/version/v2023.04.13-0-360a5007/7e7ef02/packages/kubernetes-1.24.12,kubernetes-1.25.8.tar.gz
2023-04-19 18:08:36+00:00 
2023-04-19 18:08:36+00:00 Please provide the path to the file on the server.
2023-04-19 18:08:36+00:00 Absolute path to file: main: line 5300: /dev/tty: No such device or address
2023-04-19 18:08:36+00:00 Package kubernetes-1.24.12,kubernetes-1.25.8.tar.gz not provided.
2023-04-19 18:08:36+00:00 You can provide the path to this file the next time the installer is run,
2023-04-19 18:08:36+00:00 or move it to /var/lib/kurl/assets/kubernetes-1.24.12,kubernetes-1.25.8.tar.gz to be detected automatically.
2023-04-19 18:08:36+00:00 
+ KURL_EXIT_STATUS=1
+ '[' 1 -eq 0 ']'
+ echo ''
+ echo 'failed kurl upgrade with exit status 1'
```