### PR TITLE
chore: moving tgapi base image to debian buster

### DIFF
--- a/tgapi/deploy/Dockerfile
+++ b/tgapi/deploy/Dockerfile
@@ -17,7 +17,7 @@ RUN go build -o ./bin/tgapi \
     ./cmd/api
 
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates git \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
According to https://wiki.debian.org/LTS Stretch release seems to be already out of support.

```
Debian 9 “Stretch” - From July 6, 2020 to June 30, 2022
```

This commit moves the image used by the `tgapi` to Buster (the next LTS release after Stretch):

```
Debian 10 “Buster” from August 1st, 2022 to June 30th, 2024
```

I have managed to build the image and test the binary inside of it:

```
root@d6d076a5d5b1:/# ./tgapi
Usage:
  tgapi [flags]
  tgapi [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  run

Flags:
  -h, --help   help for tgapi

Use "tgapi [command] --help" for more information about a command.
root@d6d076a5d5b1:/#
```

I believe this is what is behind these failures: https://github.com/replicatedhq/kURL-testgrid/actions/runs/4782040032/jobs/8504407664