### PR TITLE
fix: empty flag negates the rest of the arguments

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -71,10 +71,10 @@ function run_install() {
     send_logs
 
     if [ "$NUM_PRIMARY_NODES" -gt 1 ]; then
-        cat install.sh | timeout 30m bash -s $AIRGAP_FLAG "$PATCH_FLAG" ${KURL_FLAGS[@]} ekco-enable-internal-load-balancer
+        cat install.sh | timeout 30m bash -s $AIRGAP_FLAG $PATCH_FLAG ${KURL_FLAGS[@]} ekco-enable-internal-load-balancer
         KURL_EXIT_STATUS=$?
     else
-        cat install.sh | timeout 30m bash -s $AIRGAP_FLAG "$PATCH_FLAG" ${KURL_FLAGS[@]}
+        cat install.sh | timeout 30m bash -s $AIRGAP_FLAG $PATCH_FLAG ${KURL_FLAGS[@]}
         KURL_EXIT_STATUS=$?
     fi
 
@@ -126,7 +126,7 @@ function run_upgrade() {
     echo "running kurl upgrade at '$(date)'"
     send_logs
 
-    cat install.sh | timeout 60m bash -s $AIRGAP_UPGRADE_FLAG "$PATCH_FLAG" ${KURL_FLAGS[@]}
+    cat install.sh | timeout 60m bash -s $AIRGAP_UPGRADE_FLAG $PATCH_FLAG ${KURL_FLAGS[@]}
     KURL_EXIT_STATUS=$?
 
     if [ "$KURL_EXIT_STATUS" -eq 0 ]; then


### PR DESCRIPTION
```
ethan@ethanm-rook-11:~$ curl https://kurl.sh/latest | sudo bash -s  ha asdf
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  340k    0  340k    0     0   187k      0 --:--:--  0:00:01 --:--:--  187k
⚙  Running install with the argument(s): ha asdf
Error: unknown parameter "asdf"
ethan@ethanm-rook-11:~$ curl https://kurl.sh/latest | sudo bash -s "" ha asdf
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  340k    0  340k    0     0   343k      0 --:--:-- --:--:-- --:--:--  342k
⚙  Running install with the argument(s):  ha asdf
Package kurl-bin-utils-v2023.05.08-0.tar.gz already exists, not downloading
SELinux is not installed: no configuration will be applied
Awaiting 2 minutes to check kURL Pod(s) are Running
```