### PR TITLE
fix: ensure ntp is running

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/common.sh
+++ b/tgrun/pkg/runner/vmi/embed/common.sh
@@ -4,13 +4,23 @@ set -x
 
 function green()
 {
-  text="${1:-}"
-  echo -e "\033[32m$text\033[0m"
+    text="${1:-}"
+    echo -e "\033[32m$text\033[0m"
 }
 
 function command_exists()
 {
     command -v "$@" > /dev/null 2>&1
+}
+
+function ensure_ntp()
+{
+    if command_exists "apt-get" ; then
+        apt-get update
+        apt-get install -y systemd-timesyncd
+        systemctl start systemd-timesyncd
+    fi
+    timedatectl set-ntp true
 }
 
 function setup_runner()
@@ -31,6 +41,8 @@ function setup_runner()
     echo "OS INFO:"
     cat /etc/*-release
     echo ""
+
+    ensure_ntp
 }
 
 function send_logs()

--- a/tgrun/pkg/runner/vmi/embed/common.sh
+++ b/tgrun/pkg/runner/vmi/embed/common.sh
@@ -17,8 +17,8 @@ function ensure_ntp()
 {
     if command_exists "apt-get" ; then
         apt-get update
-        apt-get install -y systemd-timesyncd
-        systemctl start systemd-timesyncd
+        apt-get install -y systemd-timesyncd || true
+        systemctl start systemd-timesyncd || true
     fi
     timedatectl set-ntp true
 }


### PR DESCRIPTION
I am seeing mon clock skew detected in some rook upgrade tests. Perhaps our ntp preflight is not sufficient. I want to test this out to see if it fixes things.