### PR TITLE
fix: secondary nodes should wait longer for the test to complete

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/common.sh
+++ b/tgrun/pkg/runner/vmi/embed/common.sh
@@ -87,8 +87,8 @@ function wait_for_join_commandready()
     echo "join command not ready"
     i=$((i+1))
     # it could take up to 30 minutes to run the initial primary install script
-    # especially for OL which takes about 10 minutes to run centos2ol script
-    if [ $i -gt 30 ]; then
+    # and an additional 10 minutes for OL to run centos2ol script
+    if [ $i -gt 40 ]; then
       echo "wait_for_join_commandready timeout"
       report_status_update "failed"
       send_logs
@@ -114,7 +114,8 @@ function wait_for_initprimary_done()
     fi
     echo "initprimary not ready"
     i=$((i+1))
-    if [ $i -gt 90 ]; then
+    # we give the upgrade 180 minutes to finish plus 30 minutes padding for the cluster to become ready
+    if [ $i -gt 210 ]; then
       echo "wait_for_initprimary_done timeout"
       report_status_update "failed"
       send_logs


### PR DESCRIPTION
The rook upgrade tests are failing because the secondary nodes are not staying up long enough.

```
+ i=90
+ '[' 90 -gt 90 ']'
+ sleep 60
2023-05-16 20:54:20+00:00 initprimary not ready
+ true
++ get_initprimary_status
++ primaryNodeId=djovxjtaxxulvdvo-initialprimary
+++ curl -X GET -f https://api.testgrid.kurl.sh/v1/instance/djovxjtaxxulvdvo-initialprimary/node-status
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100    30  100    30    0     0    113      0 --:--:-- --:--:-- --:--:--   113
++ response='{"status":"joinCommandStored"}'
+++ echo '{"status":"joinCommandStored"}'
+++ sed 's/{.*status":"*\([0-9a-zA-Z]*\)"*,*.*}/\1/'
++ primaryNodeStatus=joinCommandStored
++ echo joinCommandStored
+ primaryNodeStatus=joinCommandStored
+ [[ joinCommandStored = \s\u\c\c\e\s\s ]]
+ [[ joinCommandStored = \f\a\i\l\e\d ]]
+ echo 'initprimary not ready'
+ i=91
+ '[' 91 -gt 90 ']'
+ echo 'wait_for_initprimary_done timeout'
+ report_status_update failed
```