### PR TITLE
Update request/limit for memory to 750MiB

### DIFF
--- a/tgapi/kustomize/overlays/production/deployment.yaml
+++ b/tgapi/kustomize/overlays/production/deployment.yaml
@@ -17,10 +17,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 250Mi
+              memory: 750Mi
             limits:
               cpu: 1
-              memory: 500Mi
+              memory: 750Mi
           env:
             - name: AWS_REGION
               value: us-east-1

--- a/tgapi/kustomize/overlays/staging/deployment.yaml
+++ b/tgapi/kustomize/overlays/staging/deployment.yaml
@@ -17,10 +17,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 250Mi
+              memory: 750Mi
             limits:
               cpu: 1
-              memory: 500Mi
+              memory: 750Mi
           env:
             - name: AWS_REGION
               value: us-east-1


### PR DESCRIPTION
Also set these values the same so that the pods are guaranteed their memory resources (prevents OOMKill when there's enough memory on the host to meet the request, but not enough to reach the limit).