### PR TITLE
fix: rhel 9 openssl bug

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/testhelpers.sh
+++ b/tgrun/pkg/runner/vmi/embed/testhelpers.sh
@@ -71,7 +71,7 @@ function object_store_bucket_exists() {
     local acl="x-amz-acl:private"
     local d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
     local string="HEAD\n\n\n${d}\n${acl}\n/$bucket"
-    local sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+    local sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
     curl -fsSL -I \
         --globoff \
@@ -88,7 +88,7 @@ function _object_store_create_bucket() {
   local acl="x-amz-acl:private"
   local d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
   local string="PUT\n\n\n${d}\n${acl}\n/$bucket"
-  local sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+  local sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
   curl -fsSL -X PUT  \
     --globoff \
     --noproxy "*" \
@@ -117,7 +117,7 @@ function object_store_write_object() {
   local contentType="application/x-compressed-tar"
   local d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
   local string="PUT\n\n${contentType}\n${d}\n${resource}"
-  local sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+  local sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
   curl -X PUT -T "${file}" \
     --globoff \
@@ -136,7 +136,7 @@ function object_store_get_object() {
   local contentType="application/x-compressed-tar"
   local d=$(LC_TIME="en_US.UTF-8" TZ="UTC" date +"%a, %d %b %Y %T %z")
   local string="GET\n\n${contentType}\n${d}\n${resource}"
-  local sig=$(echo -en "${string}" | openssl sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
+  local sig=$(echo -en "${string}" | openssl dgst -sha1 -hmac "${OBJECT_STORE_SECRET_KEY}" -binary | base64)
 
   curl -X GET -o "${file}" \
   --globoff \


### PR DESCRIPTION
There is a bug in openssl on rhel 9 https://github.com/openssl/openssl/pull/19606

https://testgrid.kurl.sh/run/pr-4562-80e38c2-minio-2023-06-02T23-17-26Z-k8s-docker-2023-06-05T04:07:01Z?kurlLogsInstanceId=hulpseacqcujxtlv&nodeId=hulpseacqcujxtlv-initialprimary#L0

```
+ export OBJECT_STORE_SECRET_KEY=DnIUahF1u
+ OBJECT_STORE_SECRET_KEY=DnIUahF1u
++ kubectl -n minio get service minio
++ tail -n1
++ awk '{ print $3}'
+ export OBJECT_STORE_CLUSTER_IP=10.96.0.106
+ OBJECT_STORE_CLUSTER_IP=10.96.0.106
+ validate_read_write_object_store rwtest testfile.txt
+ local bucket=rwtest
+ local file=testfile.txt
+ object_store_create_bucket rwtest
+ object_store_bucket_exists rwtest
+ local bucket=rwtest
+ local acl=x-amz-acl:private
++ LC_TIME=en_US.UTF-8
++ TZ=UTC
++ date '+%a, %d %b %Y %T %z'
+ local 'd=Mon, 05 Jun 2023 12:04:19 +0000'
+ local 'string=HEAD\n\n\nMon, 05 Jun 2023 12:04:19 +0000\nx-amz-acl:private\n/rwtest'
++ echo -en 'HEAD\n\n\nMon, 05 Jun 2023 12:04:19 +0000\nx-amz-acl:private\n/rwtest'
++ openssl sha1 -hmac DnIUahF1u -binary
Error setting context
808BE7FA3D7F0000:error:0300009E:digital envelope routines:do_sigver_init:no default digest:crypto/evp/m_sigver.c:372:
++ base64
+ local sig=
+ curl -fsSL -I --globoff --noproxy '*' -H 'Host: 10.96.0.106' -H 'Date: Mon, 05 Jun 2023 12:04:19 +0000' -H x-amz-acl:private -H 'Authorization: AWS kurl:' http://10.96.0.106/rwtest
curl: (22) The requested URL returned error: 403
+ _object_store_create_bucket rwtest
+ local bucket=rwtest
+ local acl=x-amz-acl:private
++ LC_TIME=en_US.UTF-8
++ TZ=UTC
++ date '+%a, %d %b %Y %T %z'
+ local 'd=Mon, 05 Jun 2023 12:04:19 +0000'
+ local 'string=PUT\n\n\nMon, 05 Jun 2023 12:04:19 +0000\nx-amz-acl:private\n/rwtest'
++ echo -en 'PUT\n\n\nMon, 05 Jun 2023 12:04:19 +0000\nx-amz-acl:private\n/rwtest'
++ base64
++ openssl sha1 -hmac DnIUahF1u -binary
Error setting context
80AB74F1527F0000:error:0300009E:digital envelope routines:do_sigver_init:no default digest:crypto/evp/m_sigver.c:372:
+ local sig=
+ curl -fsSL -X PUT --globoff --noproxy '*' -H 'Host: 10.96.0.106' -H 'Date: Mon, 05 Jun 2023 12:04:19 +0000' -H x-amz-acl:private -H 'Authorization: AWS kurl:' http://10.96.0.106/rwtest
2023-06-05 12:04:19+00:00 HTTP/1.1 403 Forbidden
curl: (22) The requested URL returned error: 403
+ echo 'failed to create bucket rwtest'
+ return 1
+ local exit_status=1
+ '[' 1 -ne 0 ']'
+ report_failure post_install_script
```
