### PR TITLE
fix installer_kubernets_step_versions to remove all ) so that the URL can be properly build

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/testhelpers.sh
+++ b/tgrun/pkg/runner/vmi/embed/testhelpers.sh
@@ -621,7 +621,7 @@ function installer_kubernetes_version() {
     curl -fsL "$1" | grep -m1 -A1 ' kubernetes:' | grep ' version:' | awk -F': ' '{ print $2 }'
 }
 function installer_kubernets_step_versions() {
-    curl -fsL "$1" | grep -m1 '^STEP_VERSIONS=' | sed 's/STEP_VERSIONS=(//' | sed 's/)//'
+    curl -fsL "$1" | grep -m1 '^STEP_VERSIONS=' | sed 's/STEP_VERSIONS=(//' | sed 's/)//g'
 }
 function semver_minor_version() {
     echo "$1" | sed -E 's/1\.([0-9]+)\.[0-9]+/\1/'


### PR DESCRIPTION
## Description

This PR does the change to remove ALL ) and not the first one ) found. 
See that in some cases it is not building the right URL, example:

```
curl -fLO 'https://staging.kurl.sh/bundle/10316b5/packages/kubernetes-1.20.15,kubernetes-1.21.14,kubernetes-1.22.17,kubernetes-1.23.17,kubernetes-1.24.14,kubernetes-1.25.10,kubernetes-1.26.5,kubernetes-1.27.2).tar.gz'
```

Fixes: [sc-78141]