### PR TITLE
chore: assume yes for join prompts

### DIFF
--- a/tgrun/pkg/runner/vmi/embed/primarynodecmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/primarynodecmd.sh
@@ -6,6 +6,7 @@ function runJoinCommand()
 {
   joinCommand=$(get_join_command)
   primaryJoin=$(echo "$joinCommand" | sed 's/{.*primaryJoin":"*\([0-9a-zA-Z=]*\)"*,*.*}/\1/' | base64 -d)
+  primaryJoin+=" yes" # assume yes for prompts
   eval $primaryJoin
   KURL_EXIT_STATUS=$?
 }

--- a/tgrun/pkg/runner/vmi/embed/secondarynodecmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/secondarynodecmd.sh
@@ -6,6 +6,7 @@ function runJoinCommand()
 {
   joinCommand=$(get_join_command)
   secondaryJoin=$(echo "$joinCommand" | sed 's/{.*secondaryJoin":"*\([0-9a-zA-Z=]*\)"*,*.*}/\1/' | base64 -d)
+  secondaryJoin+=" yes" # assume yes for prompts
   eval $secondaryJoin
   KURL_EXIT_STATUS=$?
 }


### PR DESCRIPTION
when there are prompts in the join flow accept them as `yes` to avoid the following:

```sh
2023-07-06 18:44:48+00:00 ✔ Node joined successfully
2023-07-06 18:44:48+00:00 ⚙  Checking proxy configuration with Containerd
2023-07-06 18:44:48+00:00 Skipping test. No HTTP proxy configuration found.
2023-07-06 18:44:48+00:00 2023/07/06 18:44:48 cluster is ready for storage migration.
2023-07-06 18:44:48+00:00     The installer detected both OpenEBS and Rook installations in your cluster. Migration from OpenEBS to Rook
2023-07-06 18:44:48+00:00     is possible now, but it requires scaling down applications using OpenEBS volumes, causing downtime. You can
2023-07-06 18:44:48+00:00     choose to run the migration later if preferred.
2023-07-06 18:44:48+00:00 Would you like to continue with the migration now? 
2023-07-06 18:44:48+00:00 (y/N) main: line 5502: /dev/tty: No such device or address
2023-07-06 18:44:48+00:00 Not migrating from OpenEBS to Rook
```