### PR TITLE
enable testgrid to run multi node tests

### DIFF
--- a/migrations/Dockerfile.okteto
+++ b/migrations/Dockerfile.okteto
@@ -1,9 +1,8 @@
-FROM schemahero/schemahero:0.13.0-alpha.1 as schemahero
+FROM schemahero/schemahero:0.14.0 as schemahero
 RUN mkdir -p /home/schemahero
 WORKDIR /home/schemahero
 
 USER root
-RUN apt-get install -y build-essential
 USER schemahero
 
 COPY tables tables

--- a/migrations/tables/kustomization.yaml
+++ b/migrations/tables/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - ./testrun.yaml
   - ./testinstance.yaml
   - ./clusternode.yaml
+  - ./testupgrade.yaml

--- a/migrations/tables/testupgrade.yaml
+++ b/migrations/tables/testupgrade.yaml
@@ -1,0 +1,17 @@
+apiVersion: schemas.schemahero.io/v1alpha4
+kind: Table
+metadata:
+  name: testupgrade
+spec:
+  database: testgrid-postgres
+  name: testupgrade
+  schema:
+    postgres:
+      primaryKey: [id, node_name]
+      columns:
+        - name: id
+          type: varchar(255)
+        - name: node_name
+          type: varchar(255)
+        - name: command
+          type: text

--- a/tgapi/pkg/cli/api/run.go
+++ b/tgapi/pkg/cli/api/run.go
@@ -55,6 +55,8 @@ func RunCmd() *cobra.Command {
 			r.HandleFunc("/v1/instance/{instanceId}/finish", handlers.FinishInstance).Methods("POST")
 			r.HandleFunc("/v1/instance/{instanceId}/join-command", handlers.AddNodeJoinCommand).Methods("POST")
 			r.HandleFunc("/v1/instance/{instanceId}/join-command", handlers.GetNodeJoinCommand).Methods("GET")
+			r.HandleFunc("/v1/instance/{instanceId}/upgrade-command/{nodeName}", handlers.AddNodeUpgradeCommand).Methods("POST")
+			r.HandleFunc("/v1/instance/{instanceId}/upgrade-command/{nodeName}", handlers.GetNodeUpgradeCommand).Methods("GET")
 			r.HandleFunc("/v1/instance/{instanceId}/status", handlers.GetRunStatus).Methods("GET")
 			r.HandleFunc("/v1/instance/{instanceId}/cluster-node", handlers.AddClusterNode).Methods("POST")
 			r.HandleFunc("/v1/instance/{nodeId}/node-status", handlers.UpdateNodeStatus).Methods("PUT")

--- a/tgapi/pkg/handlers/node_join.go
+++ b/tgapi/pkg/handlers/node_join.go
@@ -9,19 +9,19 @@ import (
 	"github.com/replicatedhq/kurl-testgrid/tgapi/pkg/testinstance"
 )
 
-type JoinPrimaryRequest struct {
+type CreateJoinCommandRequest struct {
 	PrimaryJoin   string `json:"primaryJoin"`
 	SecondaryJoin string `json:"secondaryJoin"`
 }
 
-type JoinPrimaryResponse struct {
+type GetJoinCommandResponse struct {
 	PrimaryJoin   string `json:"primaryJoin"`
 	SecondaryJoin string `json:"secondaryJoin"`
 }
 
 func AddNodeJoinCommand(w http.ResponseWriter, r *http.Request) {
-	JoinPrimaryRequest := JoinPrimaryRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&JoinPrimaryRequest); err != nil {
+	joinCommandRequest := CreateJoinCommandRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&joinCommandRequest); err != nil {
 		logger.Error(err)
 		JSON(w, 400, nil)
 		return
@@ -29,7 +29,7 @@ func AddNodeJoinCommand(w http.ResponseWriter, r *http.Request) {
 
 	instanceID := mux.Vars(r)["instanceId"]
 
-	if err := testinstance.AddNodeJoinCommand(instanceID, JoinPrimaryRequest.PrimaryJoin, JoinPrimaryRequest.SecondaryJoin); err != nil {
+	if err := testinstance.AddNodeJoinCommand(instanceID, joinCommandRequest.PrimaryJoin, joinCommandRequest.SecondaryJoin); err != nil {
 		logger.Error(err)
 		JSON(w, 500, nil)
 		return
@@ -47,8 +47,8 @@ func GetNodeJoinCommand(w http.ResponseWriter, r *http.Request) {
 		JSON(w, 500, err)
 		return
 	}
-	JoinPrimaryResponse := JoinPrimaryResponse{}
-	JoinPrimaryResponse.PrimaryJoin = primaryJoin
-	JoinPrimaryResponse.SecondaryJoin = secondaryJoin
-	JSON(w, 200, JoinPrimaryResponse)
+	joinCommandResponse := GetJoinCommandResponse{}
+	joinCommandResponse.PrimaryJoin = primaryJoin
+	joinCommandResponse.SecondaryJoin = secondaryJoin
+	JSON(w, 200, joinCommandResponse)
 }

--- a/tgapi/pkg/handlers/node_upgrade.go
+++ b/tgapi/pkg/handlers/node_upgrade.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/replicatedhq/kurl-testgrid/tgapi/pkg/logger"
+	"github.com/replicatedhq/kurl-testgrid/tgapi/pkg/testinstance"
+)
+
+type CreateNodeUpgradeRequest struct {
+	Command string `json:"command"`
+}
+
+type GetNodeUpgradeResponse struct {
+	Command string `json:"command"`
+}
+
+func AddNodeUpgradeCommand(w http.ResponseWriter, r *http.Request) {
+	joinCommandRequest := CreateNodeUpgradeRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&joinCommandRequest); err != nil {
+		logger.Error(err)
+		JSON(w, 400, nil)
+		return
+	}
+
+	instanceID := mux.Vars(r)["instanceId"]
+	nodeName := mux.Vars(r)["nodeName"]
+
+	if err := testinstance.AddNodeUpgradeCommand(instanceID, nodeName, joinCommandRequest.Command); err != nil {
+		logger.Error(err)
+		JSON(w, 500, nil)
+		return
+	}
+
+	JSON(w, 200, nil)
+}
+
+func GetNodeUpgradeCommand(w http.ResponseWriter, r *http.Request) {
+	instanceID := mux.Vars(r)["instanceId"]
+	nodeName := mux.Vars(r)["nodeName"]
+
+	command, err := testinstance.GetNodeUpgradeCommand(instanceID, nodeName)
+	if err != nil {
+		logger.Error(err)
+		JSON(w, 500, err)
+		return
+	}
+	joinCommandResponse := GetNodeUpgradeResponse{}
+	joinCommandResponse.Command = command
+	JSON(w, 200, joinCommandResponse)
+}

--- a/tgapi/pkg/testinstance/testinstance.go
+++ b/tgapi/pkg/testinstance/testinstance.go
@@ -469,6 +469,31 @@ func GetNodeJoinCommand(id string) (string, string, error) {
 	return primaryJoin.String, secondaryJoin.String, nil
 }
 
+func AddNodeUpgradeCommand(id string, nodeName string, command string) error {
+	db := persistence.MustGetPGSession()
+	query := `INSERT INTO testupgrade (id, node_name, command) VALUES ($1, $2, $3) ON CONFLICT (id, node_name) DO UPDATE SET command=EXCLUDED.command`
+
+	if _, err := db.Exec(query, id, nodeName, command); err != nil {
+		return errors.Wrap(err, "failed to update")
+	}
+
+	return nil
+}
+
+func GetNodeUpgradeCommand(id, nodeName string) (string, error) {
+	db := persistence.MustGetPGSession()
+
+	query := `select command from testupgrade where id = $1 and node_name = $2`
+	row := db.QueryRow(query, id, nodeName)
+
+	var command sql.NullString
+	if err := row.Scan(&command); err != nil {
+		return "", errors.Wrap(err, "failed to scan")
+	}
+
+	return command.String, nil
+}
+
 func GetRunStatus(id string) (bool, error) {
 	db := persistence.MustGetPGSession()
 


### PR DESCRIPTION
Adds a new table (so that multiple commands can be stored per test run) and allows setting/getting entries from that table