### PR TITLE
double the node upgrade timeout from 3 to 6 hours

### DIFF
--- a/tgrun/pkg/runner/cleanup.go
+++ b/tgrun/pkg/runner/cleanup.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	cleanupAfterMinutes = 90
-	timeoutAfterMinutes = 300
+	timeoutAfterMinutes = 480
 )
 
 // CleanUpVMIs deletes "Succeeded" VMIs
@@ -119,7 +119,7 @@ func CleanUpVMIs() error {
 }
 
 // cleanup VMIs that are not running and have not succeeded after 1.5 hours (cleanupAfterMinutes)
-// or VMIs that are running and have not succeeded after 5 hours (timeoutAfterMinutes)
+// or VMIs that are running and have not succeeded after 8 hours (timeoutAfterMinutes)
 func cleanupIsTimeout(vmi kubevirtv1.VirtualMachineInstance) bool {
 	if vmi.Status.Phase != kubevirtv1.Running && vmi.Status.Phase != kubevirtv1.Succeeded && time.Since(vmi.CreationTimestamp.Time).Minutes() > cleanupAfterMinutes {
 		return true
@@ -216,7 +216,7 @@ func cleanupPVs(clientset *kubernetes.Clientset) error {
 	return nil
 }
 
-// CleanUpSecrets removes stale cloud-init configurations stored in secrets and prevents errors on interupted runs
+// CleanUpSecrets removes stale cloud-init configurations stored in secrets and prevents errors on interrupted runs
 func cleanupSecrets(clientset *kubernetes.Clientset) error {
 	secrets, err := clientset.CoreV1().Secrets(Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {

--- a/tgrun/pkg/runner/vmi/embed/common.sh
+++ b/tgrun/pkg/runner/vmi/embed/common.sh
@@ -150,8 +150,8 @@ function wait_for_initprimary_done()
     fi
     echo "initprimary not ready"
     i=$((i+1))
-    # we give the upgrade 180 minutes to finish plus 30 minutes padding for the cluster to become ready
-    if [ $i -gt 210 ]; then
+    # we give the upgrade 360 minutes to finish plus 30 minutes padding for the cluster to become ready
+    if [ $i -gt 390 ]; then
       echo "wait_for_initprimary_done timeout"
       report_status_update "failed"
       send_logs

--- a/tgrun/pkg/runner/vmi/embed/runcmd.sh
+++ b/tgrun/pkg/runner/vmi/embed/runcmd.sh
@@ -126,7 +126,7 @@ function run_upgrade() {
     echo "running kurl upgrade at '$(date)'"
     send_logs
 
-    cat install.sh | timeout 180m bash -s $AIRGAP_UPGRADE_FLAG $PATCH_FLAG ${KURL_FLAGS[@]}
+    cat install.sh | timeout 360m bash -s $AIRGAP_UPGRADE_FLAG $PATCH_FLAG ${KURL_FLAGS[@]}
     KURL_EXIT_STATUS=$?
 
     if [ "$KURL_EXIT_STATUS" -eq 0 ]; then


### PR DESCRIPTION
Why do we need this? Because doing just the Rook 1.0.4 to 1.12.x upgrade takes ~3 hours.

Thankfully, logs are now uploaded while an upgrade is in progress, so this won't prevent us receiving feedback early if something truly does stall out.