### PR TITLE
Upgrade PDBs to policy/v1 prior to EKS upgrade

### DIFF
--- a/tgapi/kustomize/overlays/production/disruptionbudget.yaml
+++ b/tgapi/kustomize/overlays/production/disruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: tgapi

--- a/tgapi/kustomize/overlays/staging/disruptionbudget.yaml
+++ b/tgapi/kustomize/overlays/staging/disruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: tgapi


### PR DESCRIPTION
Updates Kustomize overlays for PodDisruptionBudgets to meet requirements in EKS 1.25. The API version `policy/v1beta` is deprecated and removed in 1.25.