### PR TITLE
prune test runs, then test instances

### DIFF
--- a/tgapi/pkg/persistence/prune.go
+++ b/tgapi/pkg/persistence/prune.go
@@ -11,37 +11,42 @@ func PrunePG(pruneDuration time.Duration) (int, int, error) {
 	deletedRows := 0
 	prunedRows := 0
 
-	// delete old testinstance entries
+	//// prune old testinstance output
+	//pruneBefore := time.Now().Add(-pruneDuration)
+	//result, err = pg.Exec("UPDATE testinstance SET output = '' WHERE enqueued_at < $1", pruneBefore)
+	//if err != nil {
+	//	return -1, -1, fmt.Errorf("error pruning testinstance output: %v", err)
+	//}
+	//pruned, err := result.RowsAffected()
+	//if err != nil {
+	//	return -1, -1, fmt.Errorf("error getting rows affected after pruning testinstance output: %v", err)
+	//}
+	//prunedRows += int(pruned)
+
+	// delete old testrun entries
 	deleteBefore := time.Now().Add(-pruneDuration * 3)
-	result, err := pg.Exec("DELETE FROM testinstance WHERE enqueued_at < $1", deleteBefore)
-	if err != nil {
-		return -1, -1, fmt.Errorf("error deleting testinstance entries: %v", err)
-	}
-	deleted, err := result.RowsAffected()
-	if err != nil {
-		return -1, -1, fmt.Errorf("error getting rows affected after deleting testinstance entries: %v", err)
-	}
-	deletedRows += int(deleted)
 
-	// prune old testinstance output
-	pruneBefore := time.Now().Add(-pruneDuration)
-	result, err = pg.Exec("UPDATE testinstance SET output = '' WHERE enqueued_at < $1", pruneBefore)
-	if err != nil {
-		return -1, -1, fmt.Errorf("error pruning testinstance output: %v", err)
-	}
-	pruned, err := result.RowsAffected()
-	if err != nil {
-		return -1, -1, fmt.Errorf("error getting rows affected after pruning testinstance output: %v", err)
-	}
-	prunedRows += int(pruned)
-
-	result, err = pg.Exec("DELETE FROM testrun WHERE timestamp < $1", deleteBefore)
+	runDeleteQuery := `
+DELETE FROM testrun 
+WHERE ref = any (array(SELECT ref FROM testrun WHERE enqueued_at < $1 ORDER BY enqueued_at LIMIT 1000))`
+	result, err := pg.Exec(runDeleteQuery, deleteBefore)
 	if err != nil {
 		return -1, -1, fmt.Errorf("error deleting testrun entries: %v", err)
 	}
-	deleted, err = result.RowsAffected()
+	deleted, err := result.RowsAffected()
 	if err != nil {
 		return -1, -1, fmt.Errorf("error getting rows affected after deleting testrun entries: %v", err)
+	}
+	deletedRows += int(deleted)
+
+	// delete test runs that do not have a matching testrun
+	result, err = pg.Exec("DELETE FROM testinstance WHERE testrun_ref NOT IN (SELECT ref FROM testrun)")
+	if err != nil {
+		return -1, -1, fmt.Errorf("error deleting testinstance entries: %v", err)
+	}
+	deleted, err = result.RowsAffected()
+	if err != nil {
+		return -1, -1, fmt.Errorf("error getting rows affected after deleting testinstance entries: %v", err)
 	}
 	deletedRows += int(deleted)
 


### PR DESCRIPTION
This was taking ~forever to run, so this way we can do things a bit more incrementally