### PR TITLE
chore(ci): bump the ubuntu GH runners

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -5,7 +5,7 @@ on: [ pull_request ]
 jobs:
 
   validate-go-mod:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
@@ -22,7 +22,7 @@ jobs:
       - run: go mod tidy
 
   test-tgapi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: validate-go-mod
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     - run: make -C tgapi test
 
   test-tgrun:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: validate-go-mod
     steps:
     - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
     - run: make -C tgrun test
 
   build-web:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: validate-go-mod
     steps:
     - uses: actions/setup-node@v4
@@ -68,7 +68,7 @@ jobs:
     - run: make -C web deps build-staging
 
   docker-image-tgapi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: tgapi-build
@@ -80,7 +80,7 @@ jobs:
             .
 
   docker-image-tgrun:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: tgrun-build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   staging-docker-image-tgapi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
@@ -27,7 +27,7 @@ jobs:
     - run: docker push 923411875752.dkr.ecr.us-east-1.amazonaws.com/tgapi:${GITHUB_SHA:0:7}
 
   deploy-staging-eks-tgapi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: staging-docker-image-tgapi
     steps:
     - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
           git push origin main
 
   production-docker-image-tgapi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
@@ -89,7 +89,7 @@ jobs:
     - run: docker push 799720048698.dkr.ecr.us-east-1.amazonaws.com/tgapi:${GITHUB_SHA:0:7}
 
   docker-image-tgrun:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: tgrun-build
@@ -111,7 +111,7 @@ jobs:
           docker push replicated/tgrun:${GITHUB_SHA:0:7}
 
   deploy-production-eks-tgapi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: production-docker-image-tgapi
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
See:
- https://github.com/replicatedhq/kURL-testgrid/actions/runs/14201240983/job/39788485378

![image](https://github.com/user-attachments/assets/7c737f2a-520d-4314-9042-7eb9e7458120)
