### PR TITLE
fix: pin axios to 1.13.2 to prevent upgrade to compromised 1.14.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -37,7 +37,7 @@
         "@babel/preset-react": "^7.28.5",
         "@typescript-eslint/parser": "^8.48.1",
         "autoprefixer": "^10.4.22",
-        "axios": "^1.13",
+        "axios": "1.13.2",
         "babel-loader": "^10.0.0",
         "cross-env": "^10.1.0",
         "css-loader": "^7.1.2",

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "@babel/preset-react": "^7.28.5",
     "@typescript-eslint/parser": "^8.48.1",
     "autoprefixer": "^10.4.22",
-    "axios": "^1.13",
+    "axios": "1.13.2",
     "babel-loader": "^10.0.0",
     "cross-env": "^10.1.0",
     "css-loader": "^7.1.2",


### PR DESCRIPTION
## Summary
- axios 1.14.1 and 0.30.4 have been identified as compromised npm packages containing a RAT. See https://github.com/axios/axios/issues/10604
- Pins `axios` to exact version `1.13.2` (removes `^` caret) in `web/package.json` and `web/package-lock.json`
- Prevents `npm install` from resolving to the compromised `1.14.1`

## Test plan
- [ ] Verify `npm install` in `web/` does not upgrade axios beyond 1.13.2
- [ ] Verify the web app builds and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)