### PR TITLE
add cleanup job

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,46 @@
+name: cleanup-testgrid
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to clean up'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
+      ref-id:
+        description: 'Ref ID to cancel (optional, cancels all running instances for this ref)'
+        required: false
+        default: ''
+      all-running:
+        description: 'Cancel ALL running instances older than N hours (use with caution)'
+        required: false
+        default: 'false'
+        type: boolean
+      hours:
+        description: 'Minimum age in hours to cancel (for all-running)'
+        required: false
+        default: '24'
+
+jobs:
+  cancel-by-ref:
+    if: github.event.inputs.ref-id != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel running instances by ref
+        env:
+          API_ENDPOINT: ${{ github.event.inputs.environment == 'production' && 'https://api.testgrid.kurl.sh' || 'https://api.testgrid.kurl.sh' }}
+          API_TOKEN: ${{ secrets.TESTGRID_API_TOKEN }}
+          REF_ID: ${{ github.event.inputs.ref-id }}
+        run: |
+          curl -u "token:${API_TOKEN}" \
+            -X POST \
+            "${API_ENDPOINT}/v1/ref/${REF_ID}/cancel"
+
+  # NOTE: Cancelling all running instances across all refs requires a more advanced query.
+  # The /v1/ref/{refId}/cancel endpoint cancels all running instances for a specific ref.
+  # To cancel all running instances, you would need to query the API for all running refs
+  # and then call the cancel endpoint for each one.

--- a/tgapi/pkg/cli/api/run.go
+++ b/tgapi/pkg/cli/api/run.go
@@ -47,6 +47,7 @@ func RunCmd() *cobra.Command {
 			r.HandleFunc("/api/v1/instance/{nodeId}/node-logs", handlers.GetNodeLogs).Methods("GET")
 
 			rAuth.HandleFunc("/v1/ref/{refId}/start", handlers.StartRef).Methods("POST")
+			rAuth.HandleFunc("/v1/ref/{refId}/cancel", handlers.CancelInstances).Methods("POST")
 
 			r.HandleFunc("/v1/instance/{instanceId}/start", handlers.StartInstance).Methods("POST")     // called when vm image has been loaded and k8s object created
 			r.HandleFunc("/v1/instance/{instanceId}/running", handlers.RunningInstance).Methods("POST") // called by script running within vm

--- a/tgapi/pkg/handlers/cancel_instances.go
+++ b/tgapi/pkg/handlers/cancel_instances.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/replicatedhq/kurl-testgrid/tgapi/pkg/logger"
+	"github.com/replicatedhq/kurl-testgrid/tgapi/pkg/testinstance"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"kubevirt.io/client-go/kubecli"
+)
+
+type CancelInstancesResponse struct {
+	Cancelled   int      `json:"cancelled"`
+	DeletedVMIs []string `json:"deletedVMIs,omitempty"`
+	VMIErrors   []string `json:"vmiErrors,omitempty"`
+	K8sError    string   `json:"k8sError,omitempty"`
+}
+
+// CancelInstances cancels all running (unfinished) instances for a ref and attempts
+// to delete their corresponding KubeVirt VMIs in the cluster.
+func CancelInstances(w http.ResponseWriter, r *http.Request) {
+	refID := mux.Vars(r)["refId"]
+
+	logger.Debug("cancelInstances",
+		zap.String("refId", refID))
+
+	// 1. Mark all unfinished instances as cancelled in the database
+	ids, err := testinstance.CancelRunningByRef(refID)
+	if err != nil {
+		logger.Error(err)
+		JSON(w, 500, nil)
+		return
+	}
+
+	resp := CancelInstancesResponse{
+		Cancelled: len(ids),
+	}
+
+	if len(ids) == 0 {
+		JSON(w, 200, resp)
+		return
+	}
+
+	// 2. Attempt to delete corresponding VMIs in the cluster
+	virtClient, k8sErr := getKubevirtClient()
+	if k8sErr != nil {
+		resp.K8sError = k8sErr.Error()
+		JSON(w, 200, resp)
+		return
+	}
+
+	vmiList, err := virtClient.VirtualMachineInstance("default").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		resp.K8sError = fmt.Sprintf("failed to list vmis: %v", err)
+		JSON(w, 200, resp)
+		return
+	}
+
+	for _, vmi := range vmiList.Items {
+		for _, id := range ids {
+			if strings.Contains(vmi.Name, id) {
+				err := virtClient.VirtualMachineInstance("default").Delete(context.TODO(), vmi.Name, metav1.DeleteOptions{})
+				if err != nil {
+					resp.VMIErrors = append(resp.VMIErrors, fmt.Sprintf("failed to delete vmi %s: %v", vmi.Name, err))
+				} else {
+					resp.DeletedVMIs = append(resp.DeletedVMIs, vmi.Name)
+				}
+				break
+			}
+		}
+	}
+
+	JSON(w, 200, resp)
+}
+
+func getKubevirtClient() (kubecli.KubevirtClient, error) {
+	var config *rest.Config
+	var err error
+
+	// Try in-cluster config first (when running as a pod)
+	config, err = rest.InClusterConfig()
+	if err != nil {
+		// Fall back to local kubeconfig
+		kubeconfig := filepath.Join(homeDir(), ".kube", "config")
+		if os.Getenv("KUBECONFIG") != "" {
+			kubeconfig = os.Getenv("KUBECONFIG")
+		}
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return kubecli.GetKubevirtClientFromRESTConfig(config)
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE")
+}

--- a/tgapi/pkg/testinstance/testinstance.go
+++ b/tgapi/pkg/testinstance/testinstance.go
@@ -206,6 +206,34 @@ where dequeued_at is null and testrun_ref = $1`
 	return nil
 }
 
+func CancelRunningByRef(refID string) ([]string, error) {
+	db := persistence.MustGetPGSession()
+
+	query := `
+update testinstance set
+is_success = false, failure_reason = 'cancelled',
+finished_at = now()
+where dequeued_at is not null and finished_at is null and testrun_ref = $1
+returning id`
+
+	rows, err := db.Query(query, refID)
+	if err != nil {
+		return nil, errors.Wrap(err, "db exec")
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, errors.Wrap(err, "scan id")
+		}
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+
 // List returns a list of test instances.
 // Note: pagination (limit and offset) are applied to instances with distinct kurl URLs (instances with same kurl URL count as 1)
 func List(refID string, limit int, offset int, addons map[string]string) ([]types.TestInstance, error) {


### PR DESCRIPTION
Adds an api endpoint and Github workflow to drive it, that cancels running jobs.

Motivation: there's way too many that have sat for a very long time.